### PR TITLE
feat: add global class registry

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,6 @@ export interface ClassInformation {
     name: string;
     modulePath: string;
     properties: ClassProperties;
-    id: number;
 }
 
 export interface TypeDetail {

--- a/src/webpack-angular-types-plugin/class-id-registry.ts
+++ b/src/webpack-angular-types-plugin/class-id-registry.ts
@@ -1,0 +1,46 @@
+export type WebpackModuleId = number | string;
+
+const moduleClassRegistries = new Map<WebpackModuleId, Map<string, number>>();
+const classCounter = new Map<string, number>();
+
+function getValueForKeyOrThrow<TKey, TValue>(
+    map: Map<TKey, TValue>,
+    key: TKey
+): TValue {
+    const value = map.get(key);
+    if (value === undefined) {
+        throw new Error(`Could not find value for key ${key}`);
+    }
+    return value;
+}
+
+function requestIdForClassName(className: string): number {
+    if (classCounter.has(className)) {
+        const value = getValueForKeyOrThrow(classCounter, className);
+        classCounter.set(className, value + 1);
+        return value;
+    } else {
+        classCounter.set(className, 1);
+        return 0;
+    }
+}
+
+export function getGlobalUniqueIdForClass(
+    moduleId: WebpackModuleId,
+    className: string
+): number {
+    if (!moduleClassRegistries.has(moduleId)) {
+        moduleClassRegistries.set(moduleId, new Map());
+    }
+    const moduleClassRegistry = getValueForKeyOrThrow(
+        moduleClassRegistries,
+        moduleId
+    );
+    if (moduleClassRegistry.has(className)) {
+        return getValueForKeyOrThrow(moduleClassRegistry, className);
+    } else {
+        const requestedId = requestIdForClassName(className);
+        moduleClassRegistry.set(className, requestedId);
+        return requestedId;
+    }
+}

--- a/src/webpack-angular-types-plugin/global-id-count.ts
+++ b/src/webpack-angular-types-plugin/global-id-count.ts
@@ -1,5 +1,0 @@
-let counter = 0;
-
-export function nextGlobalUniqueId() {
-    return ++counter;
-}

--- a/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
+++ b/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
@@ -1,7 +1,13 @@
 import { Dependency } from "webpack";
 
+const codeBlockStartCommentPrefix =
+    "//<webpack-angular-types-plugin-data-start>-";
+const codeBlockEndCommentPrefix = "//<webpack-angular-types-plugin-data-end>-";
+
 export class CodeDocDependency extends Dependency {
     constructor(
+        public className: string,
+        public classId: number,
         public codeDocInstructions: string,
         public uuidCodeBlock: string
     ) {
@@ -9,23 +15,52 @@ export class CodeDocDependency extends Dependency {
     }
 
     // eslint-disable-next-line
-    updateHash(hash: any) {
-        hash.update(this.codeDocInstructions);
-    }
+    /*updateHash(hash: any) {
+        hash.update(this.className);
+    }*/
 }
 
 export class CodeDocDependencyTemplate {
     // eslint-disable-next-line
     apply(myDep: CodeDocDependency, source: any) {
-        // TODO at the moment, on each reload, more and more code blocks are appended
-        //      to each source. Should there be some way to replace them so that the
-        //      window object is not cluttered with more and more unused types?
-        /*const uuidCBLength = myDep.uuidCodeBlock.length;
-        const regex = new RegExp(`$.+\\.prototype\\["${STORYBOOK_COMPONENT_ID}"]`, 'm');
-        const sourceString = source.original() as string;
-        const previousCodeBlockMatch = sourceString.match(regex);
-        const insertionStartIndex = previousCodeBlockMatch && previousCodeBlockMatch.index ? previousCodeBlockMatch.index : Infinity;*/
-        source.insert(Infinity, myDep.uuidCodeBlock);
-        source.insert(Infinity, myDep.codeDocInstructions);
+        const commentStartStr = CodeDocDependencyTemplate.constructCommentStart(
+            myDep.className
+        );
+        const commentEndStr = CodeDocDependencyTemplate.constructCommentEnd(
+            myDep.className
+        );
+        /*const sourceStr = (source.source().toString() as string);
+        const startIndex = sourceStr.indexOf(commentStartStr);
+        const endIndexFirstCharacter = sourceStr.indexOf(commentEndStr);
+        const endIndex = endIndexFirstCharacter + commentEndStr.length + 1;*/
+        const insertion = CodeDocDependencyTemplate.getInsertion(
+            commentStartStr,
+            commentEndStr,
+            myDep
+        );
+        source.insert(Infinity, insertion);
+    }
+
+    private static getInsertion(
+        startComment: string,
+        endComment: string,
+        dep: CodeDocDependency
+    ): string {
+        return (
+            startComment +
+            dep.uuidCodeBlock +
+            "\n" +
+            dep.codeDocInstructions +
+            "\n" +
+            endComment
+        );
+    }
+
+    private static constructCommentStart(className: string): string {
+        return `${codeBlockStartCommentPrefix}${className}\n`;
+    }
+
+    private static constructCommentEnd(className: string): string {
+        return `${codeBlockEndCommentPrefix}${className}\n`;
     }
 }

--- a/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
+++ b/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
@@ -14,6 +14,8 @@ export class CodeDocDependency extends Dependency {
         super();
     }
 
+    // TODO is this hash needed? Initially it did not work without it, but at
+    //      the moment, it seems to work fine
     // eslint-disable-next-line
     /*updateHash(hash: any) {
         hash.update(this.className);
@@ -29,10 +31,6 @@ export class CodeDocDependencyTemplate {
         const commentEndStr = CodeDocDependencyTemplate.constructCommentEnd(
             myDep.className
         );
-        /*const sourceStr = (source.source().toString() as string);
-        const startIndex = sourceStr.indexOf(commentStartStr);
-        const endIndexFirstCharacter = sourceStr.indexOf(commentEndStr);
-        const endIndex = endIndexFirstCharacter + commentEndStr.length + 1;*/
         const insertion = CodeDocDependencyTemplate.getInsertion(
             commentStartStr,
             commentEndStr,

--- a/src/webpack-angular-types-plugin/templating/component-arg-block-code-template.ts
+++ b/src/webpack-angular-types-plugin/templating/component-arg-block-code-template.ts
@@ -6,12 +6,10 @@ export function getComponentArgCodeBlock(
     id: number,
     types: object
 ) {
-    return `
-        if (window["${STORYBOOK_ANGULAR_ARG_TYPES}"] !== undefined) {
-            window["${STORYBOOK_ANGULAR_ARG_TYPES}"]["${componentWithIdString(
+    return `if (window["${STORYBOOK_ANGULAR_ARG_TYPES}"] !== undefined) {
+    window["${STORYBOOK_ANGULAR_ARG_TYPES}"]["${componentWithIdString(
         className,
         id
     )}"] = ${JSON.stringify(types)};
-        }
-`;
+}`;
 }

--- a/src/webpack-angular-types-plugin/templating/component-global-id-template.ts
+++ b/src/webpack-angular-types-plugin/templating/component-global-id-template.ts
@@ -8,5 +8,5 @@ export function getPrototypeComponentIDCodeBlock(
     return `${className}.prototype["${STORYBOOK_COMPONENT_ID}"] = "${componentWithIdString(
         className,
         id
-    )}"`;
+    )}";`;
 }

--- a/src/webpack-angular-types-plugin/type-extraction/type-extraction.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/type-extraction.ts
@@ -7,7 +7,6 @@ import {
     SetAccessorDeclaration,
 } from "ts-morph";
 import { ClassInformation, ClassProperties, Property } from "../../types";
-import { nextGlobalUniqueId } from "../global-id-count";
 import { removeFromMapIfExists } from "../utils";
 import {
     collectBaseClasses,
@@ -155,7 +154,6 @@ export function generateClassInformation(
             name,
             modulePath: filepath,
             properties: mergedProperties,
-            id: nextGlobalUniqueId(),
         });
     }
     return result;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "declaration": true
   },
   "include": ["src/**/*"],
   "exclude": ["src/test/**/*"]


### PR DESCRIPTION
This PR solves the problem of duplicated code in the resulting window.STORYBOOK_ARGS object. (e.g. for the same class more and more entries like "Component-0", "Component-4", "Component-9" etc. were created).

To solve this, i introduced a global id registry (instead of the previous counter). The registry now maintains class ids based on the webpack-module-id (which uniquely identifies a module also across compilation) and classes. I.e. `module-id + class-name` uniquely identifies a class.

In this manner we can maintain the same id for a given module + class across all compilations (and not introduce more and more duplicates in the process).

If this sounds confusing we can also briefly talk about it again.