### PR TITLE
Performance improvements

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Symbol as tsSymbol } from "ts-morph";
+import { Module } from "webpack";
 
 export interface Property {
     name: string;
@@ -33,7 +33,11 @@ export interface TypeDetail {
     detailString: string;
 }
 
-export type TsMorphSymbol = tsSymbol;
 export type TypeDetailCollection = Map<string, TypeDetail>;
 
 export type TypeKind = "interface" | "type" | "class" | "function";
+
+export interface ModuleInformation {
+    path: string;
+    module: Module;
+}

--- a/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
+++ b/src/webpack-angular-types-plugin/templating/code-doc-dependency.ts
@@ -14,12 +14,14 @@ export class CodeDocDependency extends Dependency {
         super();
     }
 
-    // TODO is this hash needed? Initially it did not work without it, but at
-    //      the moment, it seems to work fine
     // eslint-disable-next-line
-    /*updateHash(hash: any) {
-        hash.update(this.className);
-    }*/
+    updateHash(hash: any) {
+        // update the hash based on the most recent content, otherwise the dependency-template will
+        // not be evaluated again
+        hash.update(
+            `${this.className}:${this.classId}:${this.codeDocInstructions}:${this.uuidCodeBlock}`
+        );
+    }
 }
 
 export class CodeDocDependencyTemplate {


### PR DESCRIPTION
I introduced the usage of the "buildModule"-compilation-hook to listen to modules that will be rebuild during cold-start/hot-reload. This gives us the actual modules (a small(er) list) and not all modules of the compilation (we used `compilation.modules` before). 
Then in the seal hook i can process the collected modules and empty the moduleQueue again.

Cold-start is not really faster by this, but hot-reload now has similar loading times compared to a version without the plugin.