### PR TITLE
More fixes and features

### DIFF
--- a/src/test/angular-app/src/app/child.component.ts
+++ b/src/test/angular-app/src/app/child.component.ts
@@ -73,6 +73,7 @@ export class ChildComponent extends ParentDirective {
 
     /**
      * This is a child input
+     * @default testDefaultValue
      */
     @Input() childInput?: string = "defaultValue2";
     // eslint-disable-next-line @angular-eslint/no-input-rename
@@ -84,8 +85,12 @@ export class ChildComponent extends ParentDirective {
     @Input("setterInputWithAlias")
     set setterInput(value: boolean) {}
 
-    someNormalProperty = "";
+    someNormalProperty = [2, 5, 10];
 
+    /**
+     * This is some normal setter with a defaultValue override
+     * @default "someValue2"
+     */
     set someNormalSetter(test: string) {}
 
     constructor() {

--- a/src/test/angular-app/src/app/child.component.ts
+++ b/src/test/angular-app/src/app/child.component.ts
@@ -93,6 +93,19 @@ export class ChildComponent extends ParentDirective {
      */
     set someNormalSetter(test: string) {}
 
+    _val = 1;
+
+    /**
+     * A setter that also has a respective getter
+     * @default 1
+     */
+    set bothSetterAndGetter(val: number) {
+        this._val = val;
+    }
+    get bothSetterAndGetter() {
+        return this._val;
+    }
+
     constructor() {
         super();
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ export interface Property {
     alias?: string;
     defaultValue?: string;
     description: string;
-    // TODO what about non-primitive types, should they be expanded so they are actually useful?
     type: string;
     typeDetails?: string;
     required: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export interface WebpackAngularTypesPluginOptions {
     excludeProperties?: RegExp;
 }
 
+export type PropertyModifier = "getter" | "setter";
+
 export interface Property {
     name: string;
     alias?: string;
@@ -12,6 +14,7 @@ export interface Property {
     type: string;
     typeDetails?: string;
     required: boolean;
+    modifier?: PropertyModifier;
 }
 
 export const Categories = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import { Module } from "webpack";
 
+export interface WebpackAngularTypesPluginOptions {
+    excludeProperties?: RegExp;
+}
+
 export interface Property {
     name: string;
     alias?: string;

--- a/src/webpack-angular-types-plugin/plugin.ts
+++ b/src/webpack-angular-types-plugin/plugin.ts
@@ -1,7 +1,11 @@
 import { Project } from "ts-morph";
 import { Compiler, Module } from "webpack";
 import { DEFAULT_TS_CONFIG_PATH, PLUGIN_NAME } from "../constants";
-import { ClassInformation, ModuleInformation } from "../types";
+import {
+    ClassInformation,
+    ModuleInformation,
+    WebpackAngularTypesPluginOptions,
+} from "../types";
 import { getGlobalUniqueIdForClass } from "./class-id-registry";
 import {
     CodeDocDependency,
@@ -23,6 +27,8 @@ export class WebpackAngularTypesPlugin {
         skipLoadingLibFiles: true,
         skipFileDependencyResolution: true,
     });
+
+    constructor(private options: WebpackAngularTypesPluginOptions = {}) {}
 
     apply(compiler: Compiler) {
         compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
@@ -53,7 +59,11 @@ export class WebpackAngularTypesPlugin {
 
                 for (const { path, module } of modulesToProcess) {
                     const classInformation: ClassInformation[] =
-                        generateClassInformation(path, smallTsProject);
+                        generateClassInformation(
+                            path,
+                            smallTsProject,
+                            this.options.excludeProperties
+                        );
                     for (const ci of classInformation) {
                         this.addCodeDocDependencyToClass(ci, module);
                     }

--- a/src/webpack-angular-types-plugin/type-extraction/declaration-mappers.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/declaration-mappers.ts
@@ -6,7 +6,8 @@ import {
 } from "ts-morph";
 import { Property, TypeDetail } from "../../types";
 import {
-    getJsDocs,
+    getDefaultValue,
+    getJsDocsDescription,
     isTypeRequired,
     retrieveInputOutputDecoratorAlias,
 } from "./ast-utils";
@@ -23,8 +24,8 @@ export function mapProperty(property: PropertyDeclaration): Property {
     return {
         alias: retrieveInputOutputDecoratorAlias(property),
         name: property.getName(),
-        defaultValue: property.getInitializer()?.getText(),
-        description: getJsDocs(property),
+        defaultValue: getDefaultValue(property),
+        description: getJsDocsDescription(property),
         type: printType(property.getType(), false),
         typeDetails: stringifyTypeDetailCollection(
             generateTypeDetailCollection(
@@ -49,8 +50,8 @@ export function mapSetAccessor(setAccessor: SetAccessorDeclaration): Property {
         alias: retrieveInputOutputDecoratorAlias(setAccessor),
         name: setAccessor.getName(),
         // accessors can not have a default value
-        defaultValue: undefined,
-        description: getJsDocs(setAccessor),
+        defaultValue: getDefaultValue(setAccessor),
+        description: getJsDocsDescription(setAccessor),
         type: printType(parameter.getType(), false),
         typeDetails: stringifyTypeDetailCollection(
             generateTypeDetailCollection(
@@ -71,7 +72,7 @@ export function mapGetAccessor(getAccessor: GetAccessorDeclaration): Property {
         name: getAccessor.getName(),
         // accessors can not have a default value
         defaultValue: undefined,
-        description: getJsDocs(getAccessor),
+        description: getJsDocsDescription(getAccessor),
         type: printType(getAccessor.getType(), false),
         typeDetails: stringifyTypeDetailCollection(
             generateTypeDetailCollection(

--- a/src/webpack-angular-types-plugin/type-extraction/declaration-mappers.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/declaration-mappers.ts
@@ -60,6 +60,7 @@ export function mapSetAccessor(setAccessor: SetAccessorDeclaration): Property {
             )
         ),
         required: isTypeRequired(parameter.getType()),
+        modifier: "setter",
     };
 }
 
@@ -81,6 +82,7 @@ export function mapGetAccessor(getAccessor: GetAccessorDeclaration): Property {
             )
         ),
         required: false,
+        modifier: "getter",
     };
 }
 

--- a/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
@@ -11,6 +11,23 @@ function truncateImportPart(typeStr: string): string {
     return typeStr.replace(regex, "");
 }
 
+/*
+ * Given an array of type strings, it is searched if both the "true" and "false"
+ * boolean literal types appear in the array. If so, they are replaced by "boolean"
+ */
+function replaceTrueFalseUnionByBooleanIfExists(union: string[]): string[] {
+    // replace true/false by boolean
+    const trueIndex = union.indexOf("true");
+    const falseIndex = union.indexOf("false");
+    if (trueIndex > -1 && falseIndex > -1) {
+        union = union.filter(
+            (elem, index) => index !== trueIndex && index !== falseIndex
+        );
+        union.push("boolean");
+    }
+    return union;
+}
+
 function printUnionOrIntersection(
     type: Type,
     expandType: boolean,
@@ -23,10 +40,12 @@ function printUnionOrIntersection(
         ? type.getUnionTypes()
         : type.getIntersectionTypes();
     const joinSymbol = type.isUnion() ? " | " : " & ";
-    const res = types
-        .map((t) => printType(t, false, level + 1))
-        .join(joinSymbol);
-    return level > 0 ? wrapInBraces(res) : res;
+    let res = types.map((t) => printType(t, false, level + 1));
+    // ts-morph evaluates the boolean type as a union type of boolean literals (true | false)
+    // for printing, we want to display "boolean"
+    res = replaceTrueFalseUnionByBooleanIfExists(res);
+    const joinedRes = res.join(joinSymbol);
+    return level > 0 ? wrapInBraces(joinedRes) : joinedRes;
 }
 
 function printInterface(

--- a/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
@@ -17,15 +17,34 @@ function truncateImportPart(typeStr: string): string {
  */
 function replaceTrueFalseUnionByBooleanIfExists(union: string[]): string[] {
     // replace true/false by boolean
-    const trueIndex = union.indexOf("true");
-    const falseIndex = union.indexOf("false");
+    let res = [...union];
+    const trueIndex = res.indexOf("true");
+    const falseIndex = res.indexOf("false");
     if (trueIndex > -1 && falseIndex > -1) {
-        union = union.filter(
+        res = union.filter(
             (elem, index) => index !== trueIndex && index !== falseIndex
         );
-        union.push("boolean");
+        res.push("boolean");
     }
-    return union;
+    return res;
+}
+
+/*
+ * Moves "undefined"/"null" to the end of the string array, if present
+ */
+function pushUndefinedAndNullToEnd(arr: string[]): string[] {
+    const res = [...arr];
+    const nullIndex = res.indexOf("null");
+    if (nullIndex > -1) {
+        res.splice(nullIndex, 1);
+        res.push("null");
+    }
+    const undefinedIndex = res.indexOf("undefined");
+    if (undefinedIndex > -1) {
+        res.splice(undefinedIndex, 1);
+        res.push("undefined");
+    }
+    return res;
 }
 
 function printUnionOrIntersection(
@@ -44,6 +63,7 @@ function printUnionOrIntersection(
     // ts-morph evaluates the boolean type as a union type of boolean literals (true | false)
     // for printing, we want to display "boolean"
     res = replaceTrueFalseUnionByBooleanIfExists(res);
+    res = pushUndefinedAndNullToEnd(res);
     const joinedRes = res.join(joinSymbol);
     return level > 0 ? wrapInBraces(joinedRes) : joinedRes;
 }

--- a/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
+++ b/src/webpack-angular-types-plugin/type-extraction/type-printing.ts
@@ -81,7 +81,7 @@ function printInterface(
         const propName = property.getName();
         const propType = property.getValueDeclarationOrThrow().getType();
         // the whitespaces at the beginning are for indentation
-        res.push(`  ${propName}: ${printType(propType, false, level + 1)};`);
+        res.push(`  ${propName}: ${printType(propType, false, level)};`);
     }
     return wrapInCurlyBraces(res.join("\n"));
 }

--- a/src/webpack-angular-types-plugin/utils.ts
+++ b/src/webpack-angular-types-plugin/utils.ts
@@ -1,4 +1,16 @@
 /*
+ * Removes "key" from each passed map if the key exists
+ */
+export function removeFromMapsIfExists<TKey, TVal>(
+    maps: ReadonlyArray<Map<TKey, TVal>>,
+    key: TKey
+) {
+    for (const map of maps) {
+        removeFromMapIfExists(map, key);
+    }
+}
+
+/*
  * Removes "key" from "map" if the key exists
  */
 export function removeFromMapIfExists<TKey, TVal>(


### PR DESCRIPTION
Contains (in separate commits) the following changes:

- **feat: add excludedProperties plugin option, remove private fields from output** 
 => properties can now be excluded based on some regex. fields with the private modifier are always excluded now
- **feat: only allow literal initializers, allow override of default via jsdocs**
 => initializers are now only taken for defaultValue if they are a literal. You can now include a @default param in the jsdocs to override the default value. This is needed for setters/getters
- **feat: allow for both getter and setter usage at the same time** 
 => now both a getter and setter can be defined, while the jsdocs are only attached to one (previously the later getter/setter would override the previous jsdocs)
- **feat: replace boolean literal type by "boolean" for printing**
 => previously the type-checker would evaluate a boolean type to a union type of boolean literals (eg boolean => true | false). Now true | false is replaced by boolean again during printing
- **feat: move undefined/null to end of union/intersection types**
- **fix: remove redundant braces when printing unions/intersections in interfaces**