### PR TITLE
fix: fix array-types not being recognized properly

### DIFF
--- a/src/test/angular-app/.storybook/tsconfig.json
+++ b/src/test/angular-app/.storybook/tsconfig.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "strict": true,
     "module": "es2020",
     "target": "esnext"
   },

--- a/src/test/angular-app/src/app/child.component.ts
+++ b/src/test/angular-app/src/app/child.component.ts
@@ -51,6 +51,8 @@ export class ChildComponent extends ParentDirective<string> {
      */
     objectValue = {};
 
+    focusEvent?: FocusEvent;
+
     /**
      * Uninitialized value of type function or undefined.
      */
@@ -129,11 +131,13 @@ export class ChildComponent extends ParentDirective<string> {
      */
     // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input("setterInputWithAlias")
-    set setterInput(value: boolean) {}
+    set setterInput(value: string[]) {}
 
     get setterInput() {
-        return false;
+        return [];
     }
+
+    @Input() alternativeArrayInput?: string[];
 
     @Input() arrayInput?: Array<string>;
 

--- a/src/test/angular-app/src/app/parent.directive.ts
+++ b/src/test/angular-app/src/app/parent.directive.ts
@@ -19,6 +19,11 @@ export abstract class ParentDirective<T> extends GrandParentDirective<
     TestInterface<T>,
     string
 > {
+    @Input()
+    set setterWithTupleElement(
+        arr: Array<[string, number]> | ReadonlyArray<string>
+    ) {}
+
     @Input() test?: X<T>;
     /**
      * This is an input in the parent directive. It should also be
@@ -32,9 +37,9 @@ export abstract class ParentDirective<T> extends GrandParentDirective<
      * @default "someValue"
      */
     @Input()
-    set parentSetterInput(value: string) {}
+    set parentSetterInput(value: T[]) {}
     get parentSetterInput() {
-        return "";
+        return [];
     }
 
     /**
@@ -46,6 +51,8 @@ export abstract class ParentDirective<T> extends GrandParentDirective<
     @Input() genericTypeParameterInput?: EventEmitter<T>;
 
     @Input() literalGenericObjectInput?: { literalX: T };
+
+    @Input() inputWithoutExplicitType = 4;
 
     /**
      * This is some method with a generic parameter

--- a/src/test/angular-app/tsconfig.json
+++ b/src/test/angular-app/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
-    "declaration": false,
+    "declaration": true,
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",

--- a/src/webpack-angular-types-plugin/plugin.ts
+++ b/src/webpack-angular-types-plugin/plugin.ts
@@ -1,4 +1,4 @@
-import { Project } from "ts-morph";
+import { ModuleKind, Project, ScriptTarget } from "ts-morph";
 import { Compiler, Module } from "webpack";
 import { DEFAULT_TS_CONFIG_PATH, PLUGIN_NAME } from "../constants";
 import {
@@ -43,10 +43,11 @@ export class WebpackAngularTypesPlugin {
             });
             compilation.hooks.seal.tap(PLUGIN_NAME, () => {
                 const smallTsProject = new Project({
-                    tsConfigFilePath: DEFAULT_TS_CONFIG_PATH,
-                    skipLoadingLibFiles: true,
-                    skipAddingFilesFromTsConfig: true,
-                    skipFileDependencyResolution: true,
+                    // TODO this should be taken from the specified storybook tsconfig in the future
+                    compilerOptions: {
+                        module: ModuleKind.ES2020,
+                        target: ScriptTarget.ESNext,
+                    },
                 });
                 const modulesToProcess = this.moduleQueue
                     .map((module) => this.getProcessableModule(module))


### PR DESCRIPTION
fixes: 
- arrays not being rendered properly in the resulting docs (i.e. `string[]`, `Array<string>`, `ReadonlyArray<string>`)
- fix endless recursion when types are tuples